### PR TITLE
Add Jest setup and state change test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/changeState.js
+++ b/changeState.js
@@ -1,0 +1,18 @@
+function changeState(state) {
+  const circle = document.getElementById('circle');
+  if (!circle) return;
+  switch (state) {
+    case 'recording':
+      circle.style.backgroundColor = 'red';
+      break;
+    case 'replaying':
+      circle.style.backgroundColor = 'blue';
+      break;
+    default:
+      circle.style.backgroundColor = 'gray';
+  }
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = changeState;
+}

--- a/index.html
+++ b/index.html
@@ -27,6 +27,7 @@
 
 <body>
     <div class="circle" id="circle"></div>
+    <script src="changeState.js"></script>
     <script>
         (async function () {
 
@@ -46,18 +47,6 @@
             let audio;
             let lastBlob = null;
 
-            function changeState(state) {
-                switch (state) {
-                    case 'recording':
-                        circle.style.backgroundColor = 'red';
-                        break;
-                    case 'replaying':
-                        circle.style.backgroundColor = 'blue';
-                        break;
-                    default:
-                        circle.style.backgroundColor = 'gray';
-                }
-            }
 
             try {
                 const stream = await navigator.mediaDevices.getUserMedia({ audio: true });

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "voicerecoder",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^30.0.0-beta.3"
+  },
+  "jest": {
+    "testEnvironment": "jsdom"
+  }
+}

--- a/tests/changeState.test.js
+++ b/tests/changeState.test.js
@@ -1,0 +1,17 @@
+const changeState = require('../changeState');
+
+describe('changeState', () => {
+  let circle;
+
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="circle"></div>';
+    circle = document.getElementById('circle');
+  });
+
+  test("sets red when recording and gray when idle", () => {
+    changeState('recording');
+    expect(circle.style.backgroundColor).toBe('red');
+    changeState('idle');
+    expect(circle.style.backgroundColor).toBe('gray');
+  });
+});


### PR DESCRIPTION
## Summary
- add Node project files and jest config
- extract `changeState` function to separate file
- load `changeState.js` in `index.html`
- add a simple jest test ensuring state transitions change circle color

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683fc6a2bb20832a9a1b3b71442b44f1